### PR TITLE
perf: refine vscode development configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "program": "${command:cmake.launchTargetPath}",
       "args": [],
       "stopAtEntry": false,
-      "cwd": "${fileDirname}",
+      "cwd": "${command:cmake.launchTargetDirectory}",
       "environment": [],
       "externalConsole": false,
       "MIMode": "gdb",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,16 @@
 {
-  "python.testing.pytestArgs": ["tests"],
+  "python.testing.pytestArgs": [
+    "tests",
+    "-ra",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config"
+  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "cmake.configureOnEdit": false,
+  "cmake.options.statusBarVisibility": "icon",
   "cmake.useCMakePresets": "always",
-  "cmake.options.statusBarVisibility": "compact",
   "files.associations": {
     "iosfwd": "cpp",
     "type_traits": "cpp",

--- a/template/.vscode/launch.json.jinja
+++ b/template/.vscode/launch.json.jinja
@@ -11,7 +11,7 @@
       "program": "${command:cmake.launchTargetPath}",
       "args": [],
       "stopAtEntry": false,
-      "cwd": "${fileDirname}",
+      "cwd": "${command:cmake.launchTargetDirectory}",
       "environment": [],
       "externalConsole": false,
       "MIMode": "gdb",

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,9 +1,16 @@
 {
-  "python.testing.pytestArgs": ["tests"],
+  "python.testing.pytestArgs": [
+    "tests",
+    "-ra",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config"
+  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "cmake.configureOnEdit": false,
+  "cmake.options.statusBarVisibility": "icon",
   "cmake.useCMakePresets": "always",
-  "cmake.options.statusBarVisibility": "compact",
   "files.associations": {
     "iosfwd": "cpp",
     "type_traits": "cpp",


### PR DESCRIPTION
- Debug in the target folder
- Avoid annoying cmake automatic configuration
- Show CMake toolset with icons in status bar
- Configure pytest args