### PR TITLE
fix: vars override failure

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -245,41 +245,32 @@ default_py:
 
 ss_cmake_repo_name:
   default: '{{ repo_name }}'
-  type: str
   when: false
 
 ss_cmake_repo_url:
   default: '[% from pathjoin("includes", "variable.jinja") import repo_url with context %]{{ repo_url() }}'
-  type: str
   when: false
 
 ss_cmake_project_description:
   default: '{{ project_description }}'
-  type: str
   when: false
 
 ss_cmake_configure_coverage:
   default: false
-  type: bool
   when: false
 
 ss_cmake_configure_version:
-  default: '{{ compiled }}'
-  type: bool
-  when: false
-
-ss_cmake_configure_warnings_and_hardening:
-  default: '{{ compiled }}'
+  default: '{{ compiled == true }}'
   type: bool
   when: false
 
 ss_cmake_use_cpm:
-  default: '{{ use_cpm }}'
+  default: '{{ use_cpm == true }}'
   type: bool
   when: false
 
 ss_cmake_use_conan:
-  default: '{{ use_conan }}'
+  default: '{{ use_conan == true }}'
   type: bool
   when: false
 
@@ -287,25 +278,20 @@ ss_cmake_use_conan:
 
 ss_license_project_name:
   default: '{{ project_name }}'
-  type: str
   when: false
 
 ss_license_project_description:
   default: '{{ project_description }}'
-  type: str
   when: false
 
 ss_license_copyright_license:
   default: '{{ copyright_license }}'
-  type: str
   when: false
 
 ss_license_copyright_year:
   default: '{{ copyright_year }}'
-  type: str
   when: false
 
 ss_license_copyright_holder:
   default: '{{ copyright_holder }}'
-  type: str
   when: false


### PR DESCRIPTION
it failed to override vars in copier.yaml. Rules are below:
- delete field `type` for non-bool variable.
- keep field `type` for bool variable.